### PR TITLE
fix: replace broken schema-URL fetch with validate-multiflexi-app action

### DIFF
--- a/.github/workflows/multiflexi-validation.yml
+++ b/.github/workflows/multiflexi-validation.yml
@@ -11,52 +11,10 @@ on:
 jobs:
   validate-multiflexi-json:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
-      
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
-        
-    - name: Install jsonschema
-      run: pip install jsonschema requests
-      
-    - name: Validate JSON syntax
-      run: |
-        for file in multiflexi/*.json; do
-          if [ -f "$file" ]; then
-            echo "Validating syntax: $file"
-            python3 -m json.tool "$file" > /dev/null
-          fi
-        done
-        
-    - name: Validate against MultiFlexi schema
-      run: |
-        python3 << 'EOF'
-        import json
-        import requests
-        import jsonschema
-        import os
-        import glob
 
-        # Download the schema
-        schema_url = "https://raw.githubusercontent.com/VitexSoftware/php-vitexsoftware-multiflexi-core/refs/heads/main/multiflexi.app.schema.json"
-        response = requests.get(schema_url)
-        schema = response.json()
-
-        # Validate all JSON files
-        for file_path in glob.glob("multiflexi/*.json"):
-            print(f"Validating schema: {file_path}")
-            with open(file_path, 'r') as f:
-                data = json.load(f)
-            
-            try:
-                jsonschema.validate(data, schema)
-                print(f"✅ {file_path} is valid")
-            except jsonschema.ValidationError as e:
-                print(f"❌ {file_path} validation failed: {e.message}")
-                exit(1)
-        EOF
+    - name: Validate MultiFlexi app definitions
+      uses: VitexSoftware/validate-multiflexi-app@v1


### PR DESCRIPTION
## Summary
- The `MultiFlexi JSON Validation` workflow was failing because it downloaded the schema from `raw.githubusercontent.com/.../multiflexi.app.schema.json`, which currently 404s, causing `requests`/`jsonschema` to blow up on a non-JSON response.
- Replaced the ad-hoc python+requests+jsonschema script with the new reusable composite action [`VitexSoftware/validate-multiflexi-app@v1`](https://github.com/VitexSoftware/validate-multiflexi-app), which installs `multiflexi-cli` from `repo.multiflexi.eu` and runs `multiflexi-cli application:validate-json` against each `multiflexi/*.json` file, using the schema bundled with `php-vitexsoftware-multiflexi-core` (no network fetch of the schema at validation time).
- This same action can now be reused by any other MultiFlexi app repo that ships `multiflexi/*.app.json` files.

## Test plan
- [x] Ran `multiflexi-cli application:validate-json --file <path>` locally against all 8 files in `multiflexi/*.json` — all pass.
- [ ] Confirm the workflow run on this PR goes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation for Multiflexi application configuration files.
  * Streamlined checks by using a dedicated validation action.
  * Invalid configuration files will continue to be detected during workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->